### PR TITLE
Holy cow!

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,64 @@
 module.exports = function cashcow (get, populate) {
-  var farm = {}
+  var farm = { coop: {} }
 
-  return function cowFetch (egg) {
-    var slurry = arguments
-    if (farm[egg]) return farm[egg]
-    farm[egg] = get.apply(null, slurry).then(moo)
-    return farm[egg].catch(cowpat)
+  return function cowFetch (...eggs) {
+    if (hatch(eggs)) return hatch(eggs)
+    plant(eggs, get.apply(null, eggs).then(moo))
+    return hatch(eggs).catch(cowpat)
 
     function moo (yolk) {
-      if (populate) if (yolk === void 0) return populate.apply(null, slurry).then(huzzah)
+      if (populate) if (yolk === void 0) return populate.apply(null, eggs).then(huzzah)
       return mop(yolk)
     }
 
     function huzzah (yolk) {
       if (yolk !== void 0) return mop(yolk)
-      return get(egg).then(mop)
+      return get.apply(null, eggs).then(mop)
     }
 
     function mop (yolk) {
-      delete farm[egg]
+      sweep(eggs)
       return yolk
     }
 
     function cowpat (err) {
       throw mop(err)
+    }
+
+    function hatch (eggs, yolk) {
+      var hen = eggs.reduce((shed, egg) =>
+        shed && shed.coop[egg]
+      , farm)
+      return hen && hen.fowl
+    }
+
+    function plant (eggs, seed) {
+      eggs.reduce((shed, egg, ox) => {
+        shed.coop[egg] = shed.coop[egg] || { coop: {} }
+        if (ox === eggs.length - 1) {
+          shed.coop[egg].fowl = seed
+        }
+        return shed.coop[egg]
+      }, farm)
+    }
+
+    function sweep (eggs) {
+      var pullet = []
+      eggs.reduce((shed, egg, ox) => {
+        if (shed && shed.coop[egg]) {
+          pullet.push([shed, egg])
+        }
+        if (ox === eggs.length - 1) {
+          delete shed.coop[egg].fowl
+        }
+        return shed.coop[egg]
+      }, farm)
+      pullet.reverse().forEach(duck => {
+        var yak = duck[0].coop[duck[1]]
+        if (!yak.fowl && Object.keys(yak.coop).length === 0) {
+          delete duck[0].coop[duck[1]]
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
While this was highly fun, not sure it's a good idea to add such complicated logic to the lib.

Previously, the `apply(null, arguments)` was used in a couple of places, but
 * not here https://github.com/QubitProducts/cashcow/blob/cd3762553c1d5682fc70ca91706a201704cb8a38/index.js#L17
* and not here https://github.com/QubitProducts/cashcow/blob/cd3762553c1d5682fc70ca91706a201704cb8a38/index.js#L6

This meant, that if you try cashing a function that takes multiple arguments, those applies weren't doing much.

#### About this change

With this change, you can do this:

```js
const get = (property, experience) => {
  return cache.get(property + '/' + experience)
}
const populate = async (property, experience) => {
  const data = await axios.get(url(property, experience))
  cache.set(property + '/' + experience, data)
}
module.exports = cashcow(get, populate)
```

Before you would have had to do something like:

```js
const get = (key) => cache.get(key)
const populate = async (key) => {
  const [property, experience] = key.split('/')
  const data = await axios.get(url(property, experience))
  cache.set(key, data)
}

module.exports = (property, experience) => cashcow(get, populate)(property + '/' + experience)
```

#### Conclusions

Don't have any yet. I think maybe cashcow should remain single key. Keeps it simple. I am intrigued, however, in exploring the following API, which I think could be more versatile:

```js
cashcow(get, set)(produce, key)
```

The usage would then be more like:

```js
// cached.js
module.exports = cashcow(redis.get, redis.set)

// myfn.js
var cached = require('./cached')
// inputs can be complex objects now, not just primitives
var key = (property, experience) => property.id + experience.id 
module.exports = cached((property, experience) {
  return axios.get(url(property, experience))
}, key)

// or a simpler case - single string key
var cached = require('./cached')
module.exports = cached(key => {
  return compute(key)
})
```
